### PR TITLE
Add retry mechanism.

### DIFF
--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -84,7 +84,7 @@ func main() {
 }
 
 func post(token string, chatID chatid.ChatID, blueskyIdentifier, blueskyPassword string) error {
-	s := stamp.New(os.Getenv("STAMP_DIRECTORY"))
+	s := stamp.New(os.Getenv("STAMP_DIR"))
 
 	exists, err := s.Exists()
 	if err != nil {

--- a/deploy/savvy.pkl
+++ b/deploy/savvy.pkl
@@ -132,9 +132,17 @@ resources: Listing<K8sResource> = new {
                   }
                   volumeMounts = new {
                     new {
-                      name = "\(projectName)-stamps-pvc"
+                      name = "\(projectName)-stamps"
                       mountPath = "/stamps"
                     }
+                  }
+                }
+              }
+              volumes = new {
+                new {
+                  name = "\(projectName)-stamps"
+                  persistentVolumeClaim = new {
+                    claimName = pvc.metadata.name
                   }
                 }
               }

--- a/deploy/savvy.pkl
+++ b/deploy/savvy.pkl
@@ -4,6 +4,7 @@ import "@k8s/api/batch/v1/CronJob.pkl"
 import "@k8s/api/core/v1/ConfigMap.pkl"
 import "@k8s/api/core/v1/EnvFromSource.pkl"
 import "@k8s/api/core/v1/Namespace.pkl"
+import "@k8s/api/core/v1/PersistentVolumeClaim.pkl"
 
 local projectName = "savvy"
 
@@ -29,7 +30,7 @@ local configMap = new ConfigMap {
   }
 }
 
-local env: Listing<EnvFromSource> = new {
+local envFromSource: Listing<EnvFromSource> = new {
   new {
     configMapRef = new {
       name = configMap.metadata.name
@@ -43,10 +44,28 @@ local env: Listing<EnvFromSource> = new {
   }
 }
 
+local pvc = new PersistentVolumeClaim {
+  metadata = new {
+    name = "\(projectName)-stamps-pvc"
+    namespace = ns.metadata.name
+  }
+
+  spec = new {
+    accessModes = new { "ReadWriteOnce" }
+    resources = new {
+      requests = new {
+        ["storage"] = "1Gi"
+      }
+    }
+  }
+}
+
 resources: Listing<K8sResource> = new {
   ns
 
   configMap
+
+  pvc
 
   new Deployment {
     metadata = new {
@@ -75,7 +94,7 @@ resources: Listing<K8sResource> = new {
             new {
               name = projectName
               image = img
-              envFrom = env
+              envFrom = envFromSource
             }
           }
         }
@@ -90,7 +109,7 @@ resources: Listing<K8sResource> = new {
     }
 
     spec = new {
-      schedule = "1 15 * * *"
+      schedule = "1 15-20 * * *"
       timeZone = "Europe/Amsterdam"
       concurrencyPolicy = "Forbid"
       jobTemplate = new {
@@ -104,7 +123,19 @@ resources: Listing<K8sResource> = new {
                   name = "\(projectName)-report"
                   image = img
                   command = new { "/home/nonroot/report" }
-                  envFrom = env
+                  envFrom = envFromSource
+                  env = new {
+                    new {
+                      name = "STAMP_DIR"
+                      value = "/stamps"
+                    }
+                  }
+                  volumeMounts = new {
+                    new {
+                      name = "\(projectName)-stamps-pvc"
+                      mountPath = "/stamps"
+                    }
+                  }
                 }
               }
             }

--- a/deploy/savvy.pkl
+++ b/deploy/savvy.pkl
@@ -8,7 +8,7 @@ import "@k8s/api/core/v1/PersistentVolumeClaim.pkl"
 
 local projectName = "savvy"
 
-local tag = "v1.0.103"
+local tag = "v1.0.104"
 
 local img = "ghcr.io/heyajulia/\(projectName):\(tag)"
 
@@ -145,6 +145,12 @@ resources: Listing<K8sResource> = new {
                     claimName = pvc.metadata.name
                   }
                 }
+              }
+              securityContext = new {
+                runAsUser = 65532
+                runAsGroup = 65532
+                fsGroup = 65532
+                fsGroupChangePolicy = "OnRootMismatch"
               }
             }
           }

--- a/deploy/savvy.yml
+++ b/deploy/savvy.yml
@@ -12,6 +12,18 @@ data:
   TG_CHAT_ID: '@energieprijzen'
   BS_IDENTIFIER: did:plc:o55pshlohxgjgvsg7nusfqdf
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: savvy-stamps-pvc
+  namespace: savvy
+spec:
+  resources:
+    requests:
+      storage: 1Gi
+  accessModes:
+  - ReadWriteOnce
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -43,7 +55,7 @@ metadata:
   name: savvy-report
   namespace: savvy
 spec:
-  schedule: 1 15 * * *
+  schedule: 1 15-20 * * *
   jobTemplate:
     spec:
       template:
@@ -51,8 +63,14 @@ spec:
           restartPolicy: Never
           containers:
           - image: ghcr.io/heyajulia/savvy:v1.0.103
+            env:
+            - name: STAMP_DIR
+              value: /stamps
             command:
             - /home/nonroot/report
+            volumeMounts:
+            - mountPath: /stamps
+              name: savvy-stamps-pvc
             name: savvy-report
             envFrom:
             - configMapRef:

--- a/deploy/savvy.yml
+++ b/deploy/savvy.yml
@@ -60,6 +60,10 @@ spec:
     spec:
       template:
         spec:
+          volumes:
+          - name: savvy-stamps
+            persistentVolumeClaim:
+              claimName: savvy-stamps-pvc
           restartPolicy: Never
           containers:
           - image: ghcr.io/heyajulia/savvy:v1.0.103
@@ -70,7 +74,7 @@ spec:
             - /home/nonroot/report
             volumeMounts:
             - mountPath: /stamps
-              name: savvy-stamps-pvc
+              name: savvy-stamps
             name: savvy-report
             envFrom:
             - configMapRef:

--- a/deploy/savvy.yml
+++ b/deploy/savvy.yml
@@ -37,7 +37,7 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-      - image: ghcr.io/heyajulia/savvy:v1.0.103
+      - image: ghcr.io/heyajulia/savvy:v1.0.104
         name: savvy
         envFrom:
         - configMapRef:
@@ -60,13 +60,18 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            fsGroup: 65532
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 65532
+            runAsUser: 65532
           volumes:
           - name: savvy-stamps
             persistentVolumeClaim:
               claimName: savvy-stamps-pvc
           restartPolicy: Never
           containers:
-          - image: ghcr.io/heyajulia/savvy:v1.0.103
+          - image: ghcr.io/heyajulia/savvy:v1.0.104
             env:
             - name: STAMP_DIR
               value: /stamps

--- a/internal/stamp/stamp.go
+++ b/internal/stamp/stamp.go
@@ -1,0 +1,76 @@
+package stamp
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type Stamp struct {
+	dir string
+}
+
+func New(directory string) *Stamp {
+	return &Stamp{dir: directory}
+}
+
+func (s *Stamp) Stamp() error {
+	f, err := os.OpenFile(s.today(), os.O_CREATE|os.O_EXCL, 0644)
+	if err != nil {
+		return fmt.Errorf("stamp: create file %q: %w", s.today(), err)
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("stamp: close file %q: %w", s.today(), err)
+	}
+
+	return nil
+}
+
+func (s *Stamp) Exists() (bool, error) {
+	_, err := os.Stat(s.today())
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("stamp: stat file %q: %w", s.today(), err)
+	}
+
+	return true, nil
+}
+
+func (s *Stamp) Prune() error {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return fmt.Errorf("stamp: read directory %q: %w", s.dir, err)
+	}
+
+	keep := date()
+
+	for _, entry := range entries {
+		if entry.Name() == keep {
+			continue
+		}
+
+		path := filepath.Join(s.dir, entry.Name())
+
+		if err := os.Remove(path); err != nil {
+			slog.Warn("failed to remove old stamp", "stamp", path, "error", err)
+		}
+	}
+
+	return nil
+}
+
+func (s *Stamp) today() string {
+	return filepath.Join(s.dir, date())
+}
+
+func date() string {
+	return time.Now().Format("2006-01-02")
+}


### PR DESCRIPTION
Recently, the energy prices haven't been available at 3:01 PM on several occasions (perhaps because the auction takes longer?), causing unpredictable failures. This has required us to manually retry the job, which is inconvenient.

To fix this, this commit makes it so the CronJob runs every hour from 3:01 PM to 8:01 PM and writes a date-stamped file when the report has been posted successfully. Subsequent runs check for the existence of this file and exit early if it is present.